### PR TITLE
Fix for custom margin in data-cards block

### DIFF
--- a/blocks/data-cards/data-cards.css
+++ b/blocks/data-cards/data-cards.css
@@ -344,21 +344,25 @@
   }
 
   .data-cards.data-card-variation .rte-container > div:nth-child(2) {
-    margin-bottom: 72px;
+    margin-bottom: 0;
   }
 
   .data-cards.data-card-variation .rte-container > div:nth-child(3) {
-    margin-top: 170px;
+    margin-top: 0;
   }
 
   .data-cards.data-card-variation .rte-container > div:nth-child(2) > div > p {
     margin-top:0;
-    margin-bottom: var(--medium);
+    margin-bottom: 0;
   }
 
   .data-cards.data-card-variation .rte-container > div:nth-child(3) > div > p:first-child{
-    margin-top:0;
+    margin-top:160px;
     margin-bottom: var(--medium);
+  }
+
+  .data-cards.data-card-variation .rte-container > div:nth-child(2) > div > p >a {
+    margin-bottom: 0;
   }
 
   .data-cards.data-card-variation .data-card-items {


### PR DESCRIPTION
Fix #223

Test URLs:
- Before: https://main--world-bank--aemsites.hlx.live/
- After: https://data-cards-margin-fix--world-bank--aemsites.hlx.live/

Here fixed for the custom margin according to Figma (160px) for the data-cards block in desktop view.