### PR TITLE
spacing issue between buttons under explore by focus area on tablet

### DIFF
--- a/blocks/data-cards/data-cards.css
+++ b/blocks/data-cards/data-cards.css
@@ -70,7 +70,6 @@
 
 .data-cards.data-card-variation .rte-container > div:nth-child(3) > div > p {
   display: inline-block;
-  margin-right: var(--spacing-xxsmall);
 }
 
 .data-cards.data-card-variation .rte-container > div:nth-child(3) > div > p:first-child {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--world-bank--aemsites.hlx.live/
- After: https://316-data-cards-button-spacing-fix-on-tab--world-bank--aemsites.hlx.live/

![image](https://github.com/user-attachments/assets/d2241d06-b024-41f4-9ee5-29aa8b1f7f1f)

