### PR TITLE
Fix line-height for explore cards text

### DIFF
--- a/blocks/data-cards/data-cards.css
+++ b/blocks/data-cards/data-cards.css
@@ -87,7 +87,7 @@
 .data-cards.data-card-variation .rte-container > div:nth-child(3) > div > p:first-child {
   font-weight: 700;
   font-size: var(--font-size-500);
-  line-height: 150%;
+  line-height: 125%;
   color: var(--neutral-solid-90-s);
   display: block;
   margin-bottom: var(--spacing-medium);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #326

Test URLs:
- Before: https://main--world-bank--aemsites.hlx.live/ext/en/home
- After: https://data-cards-line-height-fix--world-bank--aemsites.hlx.live/ext/en/home
Fixed the line-height for the explore cards text.
