### PR TITLE
fix header logo and language-toggle overlap in 320px

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -1701,3 +1701,10 @@ html[dir="rtl"] header nav .nav-tools {
 input::-webkit-clear-button {
   display: none;
 }
+
+@media (width < 390px) {
+  header nav .nav-brand img {
+    width: 40vw; /* fallback */
+    width: 40dvw;
+  }
+}


### PR DESCRIPTION


Test URLs:
- Before: https://main--world-bank--aemsites.aem.live/ext/en/who-we-are/leadership/axel-van-trotsenburg
- After: https://header-logo-320--world-bank--aemsites.aem.live/ext/en/who-we-are/leadership/axel-van-trotsenburg
