### PR TITLE
fix for aquatic dark theme - high contrast bugfix

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -774,6 +774,23 @@ header nav[aria-expanded="false"] .nav-hamburger-icon::after {
   will-change: transform;
 }
 
+@media (forced-colors: active) {
+  header nav[aria-expanded="false"] .nav-hamburger-icon,
+  header nav[aria-expanded="false"] .nav-hamburger-icon::before,
+  header nav[aria-expanded="false"] .nav-hamburger-icon::after {
+    background: canvasText;
+  }
+
+  header nav[aria-expanded="true"] .nav-hamburger-icon::before,
+  header nav[aria-expanded="true"] .nav-hamburger-icon::after {
+    background: canvasText;
+  }
+
+  header .nav-menu-overlay .nav-menu-column.left > ul > li > span {
+    background: linkText !important; /* override media query in forced mode only */
+  }
+}
+
 header nav[aria-expanded="false"] .nav-hamburger-icon::before {
   top: -6px;
 }


### PR DESCRIPTION

Test URLs:
- Before: https://main--world-bank--aemsites.aem.live/ext/en/home
- After: https://high-contrast-bugfix--world-bank--aemsites.aem.live/ext/en/home

![Screenshot 2024-10-09 at 6 28 25 PM](https://github.com/user-attachments/assets/e6b7a62b-0445-461d-bf22-acf49c7ad6c3)
![Screenshot 2024-10-09 at 6 28 30 PM](https://github.com/user-attachments/assets/186271e1-78ce-4c2c-8a81-d66900eac13a)

