### PR TITLE
Hamburger subnav delay

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -423,6 +423,7 @@ export default async function decorate(block) {
     : `${PATH_PREFIX}/${langCode}/nav`;
   const fragment = await loadFragment(navPath);
   const placeholdersData = await fetchLanguagePlaceholders();
+  fetchLanguageNavigation(`/${langCode}`);
 
   // decorate nav DOM
   block.textContent = '';
@@ -505,6 +506,4 @@ export default async function decorate(block) {
   if (isDesktop.matches) await changeTrendingData(navSections);
   fetchingPlaceholdersData(placeholdersData);
   handleMainMenuFocus(block, navSections, hamburger);
-  fetchLanguageNavigation(`/${langCode}`);
-
 }

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -10,7 +10,7 @@ import {
   fetchLangDatabyFileName,
 } from '../../scripts/scripts.js';
 import {
-  getLanguage, PATH_PREFIX,
+  getLanguage, PATH_PREFIX, fetchLanguageNavigation,
 } from '../../scripts/utils.js';
 import * as constants from './constants.js';
 import {
@@ -505,4 +505,6 @@ export default async function decorate(block) {
   if (isDesktop.matches) await changeTrendingData(navSections);
   fetchingPlaceholdersData(placeholdersData);
   handleMainMenuFocus(block, navSections, hamburger);
+  fetchLanguageNavigation(`/${langCode}`);
+
 }

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -92,7 +92,7 @@ async function loadAdobeLaunch() {
 async function loadDelayed() {
   pageSwoosh();
   buildTwitterLinks();
-  getNavigationData(getLanguage());
+  // getNavigationData(getLanguage());
   if (!isInternalPage()) {
     await loadAdobeLaunch();
   }

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -21,10 +21,6 @@ function pageSwoosh() {
   }
 }
 
-const getNavigationData = async (langCode) => {
-  await fetchLanguageNavigation(`/${langCode}`);
-};
-
 // refactor tweetable links function
 /**
  * Opens a popup for the Twitter links autoblock.
@@ -92,7 +88,6 @@ async function loadAdobeLaunch() {
 async function loadDelayed() {
   pageSwoosh();
   buildTwitterLinks();
-  // getNavigationData(getLanguage());
   if (!isInternalPage()) {
     await loadAdobeLaunch();
   }

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -6,7 +6,7 @@ import {
   a, span, i,
 } from './dom-helpers.js';
 import {
-  getLanguage, fetchLanguageNavigation, isInternalPage, scriptEnabled, PATH_PREFIX,
+  isInternalPage, scriptEnabled, PATH_PREFIX,
 } from './utils.js';
 /**
  * Swoosh on page


### PR DESCRIPTION
The hamburger menu's subnav was being loaded in delay.js. Clicking on the hamburger menu before the subnav was loaded created a bad experience.
I moved the submenu load to block decoration.

Test URLs:
- Before: https://main--world-bank--aemsites.aem.live/
- After: https://fix-nav--world-bank--aemsites.aem.live/
