### PR TITLE
Fix multi-word tags used as classnames

### DIFF
--- a/blocks/data-cards/data-cards.js
+++ b/blocks/data-cards/data-cards.js
@@ -1,3 +1,4 @@
+import { toClassName } from '../../scripts/aem.js';
 import { processTags, getTaxonomy } from '../../scripts/utils.js';
 import {
   div, a, p, img, button,
@@ -6,7 +7,7 @@ import {
 async function processTag(tag) {
   const tagTxt = tag.innerText;
   if (tagTxt) {
-    tag.classList.add(processTags(tagTxt, 'category'));
+    tag.classList.add(toClassName(processTags(tagTxt, 'category')));
     tag.firstElementChild.innerText = await getTaxonomy(tagTxt, 'category');
   }
 }

--- a/blocks/mini-cards/mini-cards.js
+++ b/blocks/mini-cards/mini-cards.js
@@ -1,4 +1,4 @@
-import { createOptimizedPicture } from '../../scripts/aem.js';
+import { createOptimizedPicture, toClassName } from '../../scripts/aem.js';
 import { moveInstrumentation, CLASS_MAIN_HEADING } from '../../scripts/scripts.js';
 import { a, div } from '../../scripts/dom-helpers.js';
 import { processTags, getTaxonomy } from '../../scripts/utils.js';
@@ -6,7 +6,7 @@ import { processTags, getTaxonomy } from '../../scripts/utils.js';
 async function processTag(tag) {
   const tagTxt = tag.innerText;
   if (tagTxt) {
-    tag.classList.add(processTags(tagTxt, 'content-type'));
+    tag.classList.add(toClassName(processTags(tagTxt, 'content-type')));
     tag.firstElementChild.innerText = await getTaxonomy(tagTxt, 'content-type');
   }
 }


### PR DESCRIPTION

Test URLs:
- Before: https://main--world-bank--aemsites.aem.live/
- After: https://process-tag-classname--world-bank--aemsites.aem.live/ext/en/home
