### PR TITLE
Load analytics eagerly

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -1,13 +1,9 @@
 // add delayed functionality here
-import {
-  getMetadata, loadScript, fetchPlaceholders,
-} from './aem.js';
+import { getMetadata } from './aem.js';
 import {
   a, span, i,
 } from './dom-helpers.js';
-import {
-  isInternalPage, scriptEnabled, PATH_PREFIX,
-} from './utils.js';
+
 /**
  * Swoosh on page
  */
@@ -77,19 +73,9 @@ function buildTwitterLinks() {
   });
 }
 
-async function loadAdobeLaunch() {
-  if (!scriptEnabled()) { return; }
-
-  const config = await fetchPlaceholders(PATH_PREFIX);
-  const env = config.environment || 'Dev';
-  await loadScript(config[`analyticsEndpoint${env}`]);
-}
-
-async function loadDelayed() {
+function loadDelayed() {
   pageSwoosh();
   buildTwitterLinks();
-  if (!isInternalPage()) {
-    await loadAdobeLaunch();
-  }
 }
+
 loadDelayed();

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -12,6 +12,7 @@ import {
   loadCSS,
   fetchPlaceholders,
   getMetadata,
+  loadScript,
 } from './aem.js';
 import { picture, source, img } from './dom-helpers.js';
 
@@ -22,6 +23,8 @@ import {
   setPageLanguage,
   cookiePopUp,
   showCookieConsent,
+  isInternalPage,
+  scriptEnabled,
   PATH_PREFIX,
 } from './utils.js';
 
@@ -236,12 +239,25 @@ export async function load404() {
   return null;
 }
 
+async function loadAdobeLaunch() {
+  if (!scriptEnabled()) { return; }
+
+  const config = await fetchPlaceholders(PATH_PREFIX);
+  const env = config.environment || 'Dev';
+  await loadScript(config[`analyticsEndpoint${env}`]);
+}
+
 async function loadEager(doc) {
   setPageLanguage();
   decorateTemplateAndTheme();
   await createSkipToMainNavigationBtn();
   await cookiePopUp();
   renderWBDataLayer();
+
+  if (!isInternalPage()) {
+    await loadAdobeLaunch();
+  }
+
   const main = doc.querySelector('main');
   if (main) {
     decorateMain(main);


### PR DESCRIPTION
Test URLs:
- Before: https://main--world-bank--aemsites.aem.live/ext/en/home
- After: https://analytics-eager--world-bank--aemsites.aem.live/ext/en/home?tip=noscript
